### PR TITLE
Runtime Producer Config

### DIFF
--- a/lib/kaffe.ex
+++ b/lib/kaffe.ex
@@ -14,13 +14,7 @@ defmodule Kaffe do
 
     Logger.debug("event#start=#{__MODULE__}")
 
-    if Application.get_env(:kaffe, :producer) do
-      Logger.debug("event#start_producer_client=#{__MODULE__}")
-      Kaffe.Producer.start_producer_client()
-    end
-
     children = []
-
     opts = [strategy: :one_for_one, name: Kaffe.Supervisor]
     Supervisor.start_link(children, opts)
   end

--- a/lib/kaffe/config/producer.ex
+++ b/lib/kaffe/config/producer.ex
@@ -1,10 +1,10 @@
 defmodule Kaffe.Config.Producer do
   import Kaffe.Config, only: [heroku_kafka_endpoints: 0, parse_endpoints: 1]
 
-  def configuration do
+  def configuration(producer_overrides \\ %{}) do
     %{
       endpoints: endpoints(),
-      producer_config: client_producer_config(),
+      producer_config: client_producer_config(producer_overrides),
       client_name: config_get(:client_name, :kaffe_producer_client),
       topics: producer_topics(),
       partition_strategy: config_get(:partition_strategy, :md5)
@@ -21,8 +21,10 @@ defmodule Kaffe.Config.Producer do
     end
   end
 
-  def client_producer_config do
-    default_client_producer_config() ++ maybe_heroku_kafka_ssl() ++ sasl_options()
+  def client_producer_config(overrides) do
+    base_config = default_client_producer_config() ++ maybe_heroku_kafka_ssl() ++ sasl_options()
+    overrides_keyword_list = Enum.into(overrides, [])
+    Keyword.merge(base_config, overrides_keyword_list)
   end
 
   def sasl_options do

--- a/lib/kaffe/producer.ex
+++ b/lib/kaffe/producer.ex
@@ -27,8 +27,9 @@ defmodule Kaffe.Producer do
   ## public api
   ## -------------------------------------------------------------------------
 
-  def start_producer_client do
-    @kafka.start_client(config().endpoints, client_name(), config().producer_config)
+  def start_producer_client(opts \\ %{}) do
+    conf = config(opts)
+    @kafka.start_client(conf.endpoints, client_name(), conf.producer_config)
   end
 
   @doc """
@@ -177,7 +178,7 @@ defmodule Kaffe.Producer do
     config().partition_strategy
   end
 
-  defp config do
-    Kaffe.Config.Producer.configuration()
+  defp config(opts \\ %{}) do
+    Kaffe.Config.Producer.configuration(opts)
   end
 end

--- a/test/kaffe/config/producer_test.exs
+++ b/test/kaffe/config/producer_test.exs
@@ -1,6 +1,13 @@
 defmodule Kaffe.Config.ProducerTest do
   use ExUnit.Case, async: true
 
+  describe "configuration/1" do
+    test "custom options override values returned from base config" do
+      %{producer_config: producer_config} = Kaffe.Config.Producer.configuration(%{allow_topic_auto_creation: false})
+      assert Keyword.get(producer_config, :allow_topic_auto_creation) == false
+    end
+  end
+
   describe "configuration/0" do
     test "correct settings are extracted" do
       no_sasl_config =

--- a/test/kaffe/producer_test.exs
+++ b/test/kaffe/producer_test.exs
@@ -7,6 +7,7 @@ defmodule Kaffe.ProducerTest do
     Process.register(self(), :test_case)
     update_producer_config(:topics, ["topic", "topic2"])
     update_producer_config(:partition_strategy, :md5)
+    :ok = Kaffe.Producer.start_producer_client()
     TestBrod.set_produce_response(:ok)
     :ok
   end

--- a/test/kaffe/producer_test.exs
+++ b/test/kaffe/producer_test.exs
@@ -137,6 +137,16 @@ defmodule Kaffe.ProducerTest do
     end
   end
 
+  describe "start_link" do
+    test "can be started without any options" do
+      assert :ok == Producer.start_producer_client()
+    end
+
+    test "can be started with custom options" do
+      assert :ok == Producer.start_producer_client(%{allow_topic_auto_creation: false})
+    end
+  end
+
   defp update_producer_config(key, value) do
     producer_config = Application.get_env(:kaffe, :producer)
     Application.put_env(:kaffe, :producer, put_in(producer_config, [key], value))


### PR DESCRIPTION
* Don't automatically start producer
* Add optional argument to `Kaffe.Producer.start_producer_client` so the configuration generated by Kaffe can be overridden at the time the `kaffe.Producer` process is started.