### PR TITLE
Parse endpoints present in runtime config

### DIFF
--- a/lib/kaffe/config.ex
+++ b/lib/kaffe/config.ex
@@ -15,6 +15,13 @@ defmodule Kaffe.Config do
     |> Enum.map(&url_endpoint_to_tuple/1)
   end
 
+  def parse_overrides(overrides) do
+    case Map.get(overrides, :endpoints) do
+      nil -> overrides
+      endpoints -> Map.put(overrides, :endpoints, parse_endpoints(endpoints))
+    end
+  end
+
   def url_endpoint_to_tuple(endpoint) do
     [ip, port] = endpoint |> String.split(":")
     {ip |> String.to_atom(), port |> String.to_integer()}

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -3,13 +3,12 @@ defmodule Kaffe.Config.ConsumerTest do
 
   describe "configuration/1" do
     test "custom options override values returned from base config" do
-      expected_endpoints = [overridden: :endpoints]
-      %{endpoints: endpoints} = Kaffe.Config.Consumer.configuration(%{endpoints: expected_endpoints})
-      assert endpoints == expected_endpoints
+      %{endpoints: endpoints} = Kaffe.Config.Consumer.configuration(%{endpoints: "localhost:9092"})
+      assert endpoints == [localhost: 9092]
     end
   end
 
-  describe "base_config/0" do
+  describe "configuration/0" do
     setup do
       consumer_config =
         Application.get_env(:kaffe, :consumer)
@@ -53,7 +52,7 @@ defmodule Kaffe.Config.ConsumerTest do
         worker_allocation_strategy: :worker_per_partition
       }
 
-      assert Kaffe.Config.Consumer.base_config() == expected
+      assert Kaffe.Config.Consumer.configuration() == expected
     end
 
     test "string endpoints parsed correctly" do
@@ -91,7 +90,7 @@ defmodule Kaffe.Config.ConsumerTest do
         Application.put_env(:kaffe, :consumer, Keyword.put(config, :endpoints, endpoints))
       end)
 
-      assert Kaffe.Config.Consumer.base_config() == expected
+      assert Kaffe.Config.Consumer.configuration() == expected
     end
   end
 
@@ -133,7 +132,7 @@ defmodule Kaffe.Config.ConsumerTest do
       Application.put_env(:kaffe, :consumer, Keyword.put(config, :sasl, sasl))
     end)
 
-    assert Kaffe.Config.Consumer.base_config() == expected
+    assert Kaffe.Config.Consumer.configuration() == expected
   end
 
   describe "offset_reset_policy" do
@@ -144,7 +143,7 @@ defmodule Kaffe.Config.ConsumerTest do
 
       Application.put_env(:kaffe, :consumer, consumer_config)
 
-      assert Kaffe.Config.Consumer.base_config().offset_reset_policy == :reset_by_subscriber
+      assert Kaffe.Config.Consumer.configuration().offset_reset_policy == :reset_by_subscriber
     end
   end
 end

--- a/test/kaffe/config/producer_test.exs
+++ b/test/kaffe/config/producer_test.exs
@@ -3,8 +3,10 @@ defmodule Kaffe.Config.ProducerTest do
 
   describe "configuration/1" do
     test "custom options override values returned from base config" do
-      %{producer_config: producer_config} = Kaffe.Config.Producer.configuration(%{allow_topic_auto_creation: false})
+      overrides = %{endpoints: "localhost:9092", allow_topic_auto_creation: false}
+      %{producer_config: producer_config} = config = Kaffe.Config.Producer.configuration(overrides)
       assert Keyword.get(producer_config, :allow_topic_auto_creation) == false
+      assert Map.get(config, :endpoints) == [localhost: 9092]
     end
   end
 


### PR DESCRIPTION
* Parse endpoints present in runtime config
* Allow compile time configuration to not include the endpoints value

The more I look at the existing config code in Kaffe the more I think it should all be completely rewritten. I don't know that we want to do that now, and the changes here should give us everything we need.